### PR TITLE
Fix `float` type being passed as array index

### DIFF
--- a/pytsmod/tdpsolatsm.py
+++ b/pytsmod/tdpsolatsm.py
@@ -141,7 +141,7 @@ def _target_f0_to_beta(x, pitch_mark, source_f0, target_f0):
     """
     beta = np.zeros(pitch_mark.size)
     for i in range(beta.size):
-        idx = round(pitch_mark[i] * source_f0.size / x.size)
+        idx = int(round(pitch_mark[i] * source_f0.size / x.size))
         if idx < 0:
             idx = 0
         elif idx >= source_f0.size:


### PR DESCRIPTION
## What does this PR do? (is there any related issue about this PR?)
Prevents indexing error due to float valued `idx`

## Why are we doing this?
`round` can return a float value sometimes, and that can break passing it as an index later on

## How to test the new code?

## Other comments
